### PR TITLE
Debugging

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -27,10 +27,10 @@ Create a yml config file for your collection going to a Solr index.
 See  spec/config/ap.yml for an example.
 
 You will want to copy that file and change the following settings:
-1. log_name
+1. log_name, log_dir, and log_level
 2. default_set (in OAI harvesting params section)
-2a. other OAI harvesting params
-3. blacklist or whitelist if you are using them
+3. other OAI harvesting params
+4. blacklist or whitelist if you are using them
 
 You can also pass in non-default configurations as a hash
 
@@ -42,25 +42,25 @@ In your code, override this method from the Harvestdor::Indexer class
 
 # create Solr doc for the druid and add it to Solr, unless it is on the blacklist.  
 #  NOTE: don't forget to send commit to Solr, either once at end (already in harvest_and_index), or for each add, or ...
-def index druid
-  if blacklist.include?(druid)
-    logger.info("Druid #{druid} is on the blacklist and will have no Solr doc created")
-  else
-    logger.error("You must override the index method to transform druids into Solr docs and add them to Solr")
+  def index druid
+    if blacklist.include?(druid)
+      logger.info("Druid #{druid} is on the blacklist and will have no Solr doc created")
+    else
+      logger.error("You must override the index method to transform druids into Solr docs and add them to Solr")
     
-    doc_hash = {}
-    doc_hash[:id] = druid
-    # doc_hash[:title_tsim] = smods_rec(druid).short_title
+      doc_hash = {}
+      doc_hash[:id] = druid
+      # doc_hash[:title_tsim] = smods_rec(druid).short_title
 
-    # you might add things from Indexer level class here
-    #  (e.g. things that are the same across all documents in the harvest)
+      # you might add things from Indexer level class here
+      #  (e.g. things that are the same across all documents in the harvest)
 
-    solr_client.add(doc_hash)
+      solr_client.add(doc_hash)
 
-    # logger.info("Just created Solr doc for #{druid}")
-    # TODO: provide call to code to update DOR object's workflow datastream??
+      # logger.info("Just created Solr doc for #{druid}")
+      # TODO: provide call to code to update DOR object's workflow datastream??
+    end
   end
-end
 
 === Run it
 
@@ -68,27 +68,24 @@ end
 
 I suggest you write a script to run the code.  Your script might look like this:
 
-	#!/usr/bin/env ruby
+  #!/usr/bin/env ruby
+  $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
+  $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+  require 'rubygems'
+  begin
+    require 'your_indexer'
+    rescue LoadError
+      require 'bundler/setup'
+      require 'your_indexer'
+  end
+  config_yml_path = ARGV.pop
+  if config_yml_path.nil?
+    puts "** You must provide the full path to a config yml file **"
+    exit
+  end
 
-	$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..'))
-	$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-
-	require 'rubygems'
-	begin
-	  require 'your_indexer'
-	rescue LoadError
-	  require 'bundler/setup'
-	  require 'your_indexer'
-	end
-
-	config_yml_path = ARGV.pop
-	if config_yml_path.nil?
-	  puts "** You must provide the full path to a config yml file **"
-	  exit
-	end
-  
-	indexer = Harvestdor::Indexer.new(config_yml_path, opts)
-	indexer.harvest_and_index
+  indexer = Harvestdor::Indexer.new(config_yml_path, opts)
+  indexer.harvest_and_index
 
 Then you run the script like so:
 

--- a/lib/harvestdor-indexer.rb
+++ b/lib/harvestdor-indexer.rb
@@ -17,6 +17,7 @@ module Harvestdor
 
     attr_accessor :error_count, :success_count, :max_retries
     attr_accessor :total_time_to_parse,:total_time_to_solr
+    attr_reader   :log_level
 
     def initialize yml_path, options = {}
       @success_count=0    # the number of objects successfully indexed
@@ -27,6 +28,7 @@ module Harvestdor
       @yml_path = yml_path
       config.configure(YAML.load_file(yml_path)) if yml_path    
       config.configure options 
+      @log_level = config.log_level ? config.log_level : Logger::INFO
       yield(config) if block_given?
     end
 
@@ -35,7 +37,16 @@ module Harvestdor
     end
 
     def logger
-      @logger ||= load_logger(config.log_dir, config.log_name)
+      @logger ||= load_logger(config.log_dir, config.log_name, @log_level)
+    end
+    
+    
+    # Set the log level
+    # @param [Integer] level Valid values are Logger::DEBUG, Logger::INFO, Logger::WARN, Logger::FATAL
+    def set_log_level(level)
+      @logger = logger unless(@logger) # Initialize @logger if it hasn't happened yet
+      @log_level = level
+      @logger.level = level
     end
 
     # per this Indexer's config options 
@@ -73,7 +84,7 @@ module Harvestdor
         start_time=Time.now
         logger.info("Starting OAI harvest of druids at #{start_time}.")  
         @druids = harvestdor_client.druids_via_oai
-        logger.info("Completed OAI harves of druids at #{Time.now}.  Found #{@druids.size} druids.  Total elapsed time for OAI harvest = #{elapsed_time(start_time,:minutes)} minutes")  
+        logger.info("Completed OAI harvest of druids at #{Time.now}.  Found #{@druids.size} druids.  Total elapsed time for OAI harvest = #{elapsed_time(start_time,:minutes)} minutes")  
       end
       return @druids
     end
@@ -81,6 +92,7 @@ module Harvestdor
     # Add the document to solr, retry if an error occurs.
     # @param [Hash] doc a Hash representation of the solr document
     # @param [String] id the id of the document being sent, for logging
+    # @param [Boolean] do_retry whether or not to attempt a re-try if an error is encountered
     def solr_add(doc, id, do_retry=true)
       #if do_retry is false, skip retrying 
       tries=do_retry ? 0 : 999
@@ -88,7 +100,7 @@ module Harvestdor
       while tries < max_tries
       begin
         tries+=1
-        logger.info "Try #{tries} for #{id}"
+        logger.debug "Try #{tries} for #{id}"
         solr_client.add(doc)
         #return if successful
         logger.info "Successfully indexed #{id} on try #{tries}"
@@ -101,7 +113,7 @@ module Harvestdor
           # The "can not set IO blocking after select" errors we sometimes get are because threads are 
           # attempting to grab the same socket. This should space things out.
           retry_wait = Random.new.rand(5..10)
-          logger.warn "Letting #{id} rest for #{retry_wait} seconds..."
+          logger.debug "Letting #{id} rest for #{retry_wait} seconds..."
           sleep retry_wait # If we fail the first time, sleep and try again
         else
           @error_count+=1
@@ -115,6 +127,7 @@ module Harvestdor
 
     # create Solr doc for the druid and add it to Solr, unless it is on the blacklist.  
     #  NOTE: don't forget to send commit to Solr, either once at end (already in harvest_and_index), or for each add, or ...
+    # @param [String] druid
     def index druid
       if blacklist.include?(druid)
         logger.info("Druid #{druid} is on the blacklist and will have no Solr doc created")
@@ -301,9 +314,18 @@ module Harvestdor
     # Global, memoized, lazy initialized instance of a logger
     # @param [String] log_dir directory for to get log file
     # @param [String] log_name name of log file
-    def load_logger(log_dir, log_name)
+    # @param [Integer] log_level One of Logger::DEBUG, Logger::INFO, etc. See http://www.ruby-doc.org/stdlib-2.0/libdoc/logger/rdoc/Logger/Severity.html
+    def load_logger(log_dir, log_name, log_level=@log_level)
+      # Check for log_dir and log_name
+      throw "No log_dir value set" unless log_dir
+      throw "No log_name value set" unless log_name
       Dir.mkdir(log_dir) unless File.directory?(log_dir) 
-      @logger ||= Logger.new(File.join(log_dir, log_name), 'daily')
+      @logger ||= 
+        begin
+          log = Logger.new(File.join(log_dir, log_name), 'daily')
+          log.level = log_level
+          log
+        end
     end
 
   end # Indexer class

--- a/spec/config/ap.yml
+++ b/spec/config/ap.yml
@@ -11,6 +11,10 @@ log_dir: spec/test_logs
 # log_name: name of log file  (default: harvestdor.log)
 log_name: ap-test.log
 
+# log_level: level of logging for this collection
+# possible values are 0 (Logger::DEBUG), 1 (Logger::INFO), 2 (Logger::WARN), 3 (Logger::ERROR)
+# log_level: 0
+
 # purl: url for the DOR purl server (used to get ContentMetadata, etc.)
 purl: http://purl.stanford.edu
 

--- a/spec/unit/harvestdor-indexer_spec.rb
+++ b/spec/unit/harvestdor-indexer_spec.rb
@@ -52,6 +52,19 @@ describe Harvestdor::Indexer do
       @indexer.logger.info("indexer_spec logging test message")
       File.exists?(File.join(@yaml['log_dir'], @yaml['log_name'])).should == true
     end
+    it "by default logs at INFO level" do
+      indexer = Harvestdor::Indexer.new(@config_yml_path)
+      expect(indexer.logger.level).to eql(Logger::INFO)
+    end
+    it "can set log levels easily" do
+      indexer = Harvestdor::Indexer.new(@config_yml_path)
+      indexer.set_log_level(Logger::WARN)
+      expect(indexer.logger.level).to eql(Logger::WARN)
+    end
+    it "can set log levels from a config" do
+      indexer = Harvestdor::Indexer.new(nil, Confstruct::Configuration.new(:log_level => Logger::FATAL, :log_dir => '/tmp/foo', :log_name => 'mylog'))
+      expect(indexer.logger.level).to eql(Logger::FATAL)
+    end
   end
   
   it "should initialize the harvestdor_client from the config" do


### PR DESCRIPTION
I like the idea of having some messages be debug and some info, but that sort of implies that we can set the log level to turn off the debug messages, so I added that ability. This will now allow us to add log_level to any of the .yml files if we want to see all the debugging statements about what's happening in a collection, and then turn them back off for routine runs so our log files aren't so verbose.

I think it's better for the success message to be at info level, but the retrying messages to be debug. Ideally, we shouldn't care that it's retrying, that should just happen in the background. Unless we're debugging, the only thing we really want in the log is success or failure. 

@ndushay Could you take a look at merging this? Thanks!
